### PR TITLE
Fix registration of Hawtio Quarkus extension

### DIFF
--- a/examples/quarkus/pom.xml
+++ b/examples/quarkus/pom.xml
@@ -74,6 +74,13 @@
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-management</artifactId>
     </dependency>
+
+    <!-- To enable Camel route dumping to XML. Required for the route diagram -->
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jaxb</artifactId>
+    </dependency>
+
     <!--
       To enable Camel plugin debugging feature, add this dependency.
     -->
@@ -101,7 +108,7 @@
     <!-- Hawtio -->
     <dependency>
       <groupId>io.hawt</groupId>
-      <artifactId>hawtio-quarkus-deployment</artifactId>
+      <artifactId>hawtio-quarkus</artifactId>
     </dependency>
 
     <!-- Testing -->

--- a/platforms/quarkus/runtime/pom.xml
+++ b/platforms/quarkus/runtime/pom.xml
@@ -78,7 +78,7 @@
             </goals>
             <configuration>
               <target>
-                <copy file="${project.build.outputDirectory}/META-INF/resources/hawtio/WEB-INF/web.xml" todir="${project.build.directory}/classes/META-INF/" />
+                <move file="${project.build.outputDirectory}/META-INF/resources/hawtio/WEB-INF/web.xml" todir="${project.build.directory}/classes/META-INF/" />
               </target>
             </configuration>
           </execution>
@@ -86,8 +86,18 @@
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
         <version>${quarkus-version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>extension-descriptor</goal>
+            </goals>
+            <configuration>
+              <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This at least gets the app to run. But there's a 404 when you try to access the app.

I don't know if `HawtioQuarkusPathFilter` is relevant anymore now that the frontend has moved away from Angular. So maybe it should be removed or replaced with a different implementation.